### PR TITLE
✨ feat : 회원가입 및 selectMT 스크린 구현, 로그린/회원가입 api 연동

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -41,7 +41,7 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_pdfview: 25f53dd6097661e6395b17de506e6060585946bd
   image_picker_ios: 99dfe1854b4fa34d0364e74a78448a0151025425

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1510;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1510"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/lib/models/login/sign_state.dart
+++ b/lib/models/login/sign_state.dart
@@ -1,0 +1,29 @@
+class User {
+  String email;
+  String password;
+  String name;
+  String phone;
+  String membertype;
+
+  User({required this.email, required this.password, required this.name, required this.phone, required this.membertype});
+
+  factory User.fromJson(Map<String, dynamic> json) {
+    return User(
+      email: json['email'] as String,
+      password: json['password'] as String,
+      name: json['name'] as String,
+      phone: json['phone'] as String,
+      membertype: json['memberType'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'email': email,
+      'password': password,
+      'name': name,
+      'phone': phone,
+      'memberType': membertype,
+    };
+  }
+}

--- a/lib/services/login_service.dart
+++ b/lib/services/login_service.dart
@@ -1,45 +1,47 @@
 // user_service.dart
 import 'package:http/http.dart' as http;
 import 'dart:convert';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class UserService {
-  //  Future<bool> attemptLogIn(String email, String password) async {
-  //   final response = await http.post(
-  //     Uri.parse('여기에_API_엔드포인트_URL_추가'),
-  //     headers: {'Content-Type': 'application/json'},
-  //     body: json.encode({
-  //       'email': email,
-  //       'password': password,
-  //     }),
-  //   );
-  //
-  //   return response.statusCode == 200;
-  // }
+  String? loginAPI = dotenv.env['loginAPI'];
 
-  Future<bool> attemptLogIn(String email, String password) async {
-    // 인위적인 지연을 만들어 실제 API 호출과 유사한 상황을 만듭니다.
-    await Future.delayed(Duration(seconds: 2));
-
-    // 예제를 위한 더미 응답 데이터
-    var dummyResponse = {
-      'statusCode': 200,
-      'body': json.encode({
-        'message': 'Success',
-        'user': {
-          'id': 1,
-          'name': '사용자 이름',
-          'email': email,
-          // 다른 사용자 정보들
-        }
+   Future<bool> attemptLogIn(String email, String password) async {
+    final response = await http.post(
+      Uri.parse(loginAPI!),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({
+        'email': email,
+        'password': password,
       }),
-    };
-
-    if (email == '1' && password == '1') {
-      print('더미 로그인 성공: ${dummyResponse['body']}');
-      return true; // 성공으로 간주
-    } else {
-      print('더미 로그인 실패');
-      return false; // 실패로 간주
-    }
+    );
+    return response.statusCode == 200;
   }
+
+  // Future<bool> attemptLogIn(String email, String password) async {
+  //   // 인위적인 지연을 만들어 실제 API 호출과 유사한 상황을 만듭니다.
+  //   await Future.delayed(Duration(seconds: 2));
+  //
+  //   // 예제를 위한 더미 응답 데이터
+  //   var dummyResponse = {
+  //     'statusCode': 200,
+  //     'body': json.encode({
+  //       'message': 'Success',
+  //       'user': {
+  //         'id': 1,
+  //         'name': '사용자 이름',
+  //         'email': email,
+  //         // 다른 사용자 정보들
+  //       }
+  //     }),
+  //   };
+  //
+  //   if (email == '1' && password == '1') {
+  //     print('더미 로그인 성공: ${dummyResponse['body']}');
+  //     return true; // 성공으로 간주
+  //   } else {
+  //     print('더미 로그인 실패');
+  //     return false; // 실패로 간주
+  //   }
+  // }
 }

--- a/lib/services/sign_service.dart
+++ b/lib/services/sign_service.dart
@@ -1,0 +1,22 @@
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class UserSignInService {
+  String? signAPI = dotenv.env['signAPI'];
+
+  Future<bool> attemptSignIn(String email, String password, String name, String phone, String memberType) async {
+    final response = await http.post(
+      Uri.parse(signAPI!),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({
+        'email': email,
+        'password': password,
+        'name': name,
+        'phone': phone,
+        'memberType': memberType,
+      }),
+    );
+    return response.statusCode == 200;
+  }
+}

--- a/lib/utilities/font_system.dart
+++ b/lib/utilities/font_system.dart
@@ -201,6 +201,20 @@ abstract class FontSystem {
     color: Colors.black,
   );
 
+  static const TextStyle KR17SB = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w600,
+    fontFamily: 'Pretendard',
+    color: Colors.black,
+  );
+
+  static const TextStyle KR15SB = TextStyle(
+    fontSize: 16,
+    fontWeight: FontWeight.w600,
+    fontFamily: 'Pretendard',
+    color: Colors.black,
+  );
+
   static const TextStyle KR16M = TextStyle(
     fontSize: 16,
     fontWeight: FontWeight.w500,

--- a/lib/viewModels/login/signin_viewmodel.dart
+++ b/lib/viewModels/login/signin_viewmodel.dart
@@ -5,6 +5,7 @@ import '../../services/sign_service.dart';
 class SignInViewModel {
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
+  final TextEditingController confirmPasswordController = TextEditingController();
   final TextEditingController nameController = TextEditingController();
   final TextEditingController phoneController = TextEditingController();
   final TextEditingController membertypeController = TextEditingController();
@@ -17,7 +18,7 @@ class SignInViewModel {
     print("Phone: ${phoneController.text}");
     print("MemberType: ${membertypeController.text}");
   }
-  // 일단 관리자/멤버는 남겨둚
+
   Future<bool> attemptSignIn() async {
     return _userService.attemptSignIn(
       emailController.text,

--- a/lib/viewModels/login/signin_viewmodel.dart
+++ b/lib/viewModels/login/signin_viewmodel.dart
@@ -1,0 +1,30 @@
+import 'package:bommeong/models/login/sign_state.dart';
+import 'package:flutter/material.dart';
+import '../../services/sign_service.dart';
+
+class SignInViewModel {
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+  final TextEditingController nameController = TextEditingController();
+  final TextEditingController phoneController = TextEditingController();
+  final TextEditingController membertypeController = TextEditingController();
+  final UserSignInService _userService = UserSignInService();
+
+  void printAllControllerValues() {
+    print("Email: ${emailController.text}");
+    print("Password: ${passwordController.text}");
+    print("Name: ${nameController.text}");
+    print("Phone: ${phoneController.text}");
+    print("MemberType: ${membertypeController.text}");
+  }
+  // 일단 관리자/멤버는 남겨둚
+  Future<bool> attemptSignIn() async {
+    return _userService.attemptSignIn(
+      emailController.text,
+      passwordController.text,
+      nameController.text,
+      phoneController.text,
+      membertypeController.text,
+    );
+  }
+}

--- a/lib/views/login/login_screen.dart
+++ b/lib/views/login/login_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bommeong/views/login/loading_screen.dart';
+import 'package:bommeong/views/login/signin_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_svg/svg.dart';
@@ -127,7 +128,9 @@ class LoginScreen extends StatelessWidget {
                 children: [
                   Expanded(
                     child: TextButton(
-                      onPressed: () {},
+                      onPressed: () {
+                        Get.to(SignInScreen());
+                      },
                       child: Text(
                         '비밀번호 찾기',
                         textAlign: TextAlign.right, // 오른쪽 정렬

--- a/lib/views/login/login_screen.dart
+++ b/lib/views/login/login_screen.dart
@@ -9,10 +9,7 @@ import 'package:intl/date_symbol_data_file.dart';
 import '../../viewModels/login/login_viewmodel.dart';
 
 void main() async {
-  /* Open .env file */
   await dotenv.load(fileName: "assets/config/.env");
-
-  // Splash Screen Duration 1.0s
   await Future.delayed(const Duration(seconds: 1));
 
   runApp(MyApp());

--- a/lib/views/login/login_screen.dart
+++ b/lib/views/login/login_screen.dart
@@ -1,4 +1,5 @@
 import 'package:bommeong/views/login/loading_screen.dart';
+import 'package:bommeong/views/login/selectmt_screen.dart';
 import 'package:bommeong/views/login/signin_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -128,9 +129,7 @@ class LoginScreen extends StatelessWidget {
                 children: [
                   Expanded(
                     child: TextButton(
-                      onPressed: () {
-                        Get.to(SignInScreen());
-                      },
+                      onPressed: () {},
                       child: Text(
                         '비밀번호 찾기',
                         textAlign: TextAlign.right, // 오른쪽 정렬
@@ -156,7 +155,7 @@ class LoginScreen extends StatelessWidget {
                   ),
                   Expanded(
                     child: TextButton(
-                      onPressed: () {},
+                      onPressed: () {Get.to(SelectMTScreen());},
                       child: Text(
                         '회원가입',
                         textAlign: TextAlign.left, // 왼쪽 정렬

--- a/lib/views/login/login_screen.dart
+++ b/lib/views/login/login_screen.dart
@@ -1,12 +1,22 @@
 import 'package:bommeong/views/login/loading_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:get/get_core/src/get_main.dart';
 import 'package:get/get_navigation/src/root/get_material_app.dart';
+import 'package:intl/date_symbol_data_file.dart';
 import '../../viewModels/login/login_viewmodel.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  /* Open .env file */
+  await dotenv.load(fileName: "assets/config/.env");
+
+  // Splash Screen Duration 1.0s
+  await Future.delayed(const Duration(seconds: 1));
+
+  runApp(MyApp());
+}
 
 class MyApp extends StatelessWidget {
   @override

--- a/lib/views/login/selectmt_screen.dart
+++ b/lib/views/login/selectmt_screen.dart
@@ -1,0 +1,96 @@
+import 'package:bommeong/views/login/signin_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../utilities/font_system.dart';
+
+class SelectMTScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: HelloWidget(),
+    );
+  }
+}
+
+class HelloWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: EdgeInsets.all(40),
+          child: RichText(
+            textAlign: TextAlign.left,
+            text: TextSpan(
+              style: TextStyle(
+                fontSize: 24.0,
+                fontFamily: 'Pretendard',
+                fontWeight: FontWeight.bold,
+                color: Colors.black,
+              ),
+              children: <TextSpan>[
+                TextSpan(text: '반가워요!\n\n', style: TextStyle(fontSize: 26.0)),
+                TextSpan(text: '봄멍', style: TextStyle(color: Color(0xFFA273FF))),
+                TextSpan(text: '엔\n어떤 이유로\n찾아오셨나요?'),
+              ],
+            ),
+          ),
+        ),
+        Spacer(flex: 2),
+        _BottomButton(
+          buttonText: '유기견 입양하기',
+          backgroundColor: Color(0xFFA273FF),
+          onTap: () {
+            Get.to(() => SignInScreen(membertype: "B"));
+          },
+        ),
+        SizedBox(height: 20,),
+        _BottomButton(
+          buttonText: '입양 공고 게시하기',
+          backgroundColor: Color(0xFFCCB7F7),
+          onTap: () {
+            Get.to(() => SignInScreen(membertype: "S"));
+          },
+        ),
+        SizedBox(height: 50,),
+      ],
+    );
+  }
+}
+
+
+class _BottomButton extends StatelessWidget {
+  final String buttonText;
+  final Color backgroundColor;
+  final VoidCallback onTap;
+
+  _BottomButton({
+    required this.buttonText,
+    required this.backgroundColor,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: InkWell(
+        onTap: onTap, // onTap 콜백 사용
+        child: Container(
+          width: Get.width * 0.85,
+          padding: EdgeInsets.symmetric(vertical: 15, horizontal: 30),
+          decoration: BoxDecoration(
+            color: backgroundColor, // 배경색 설정
+            borderRadius: BorderRadius.circular(10), // 모서리 둥글기 반경 설정
+          ),
+          child: Text(
+            buttonText, // 버튼 텍스트
+            style: FontSystem.KR16B.copyWith(color: Colors.white),
+            textAlign: TextAlign.center, // 텍스트 정렬
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/login/signin_screen.dart
+++ b/lib/views/login/signin_screen.dart
@@ -1,0 +1,147 @@
+import 'package:bommeong/viewModels/login/signin_viewmodel.dart';
+import 'package:bommeong/views/login/login_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:get/get_core/src/get_main.dart';
+
+class SignInScreen extends StatelessWidget {
+  final viewModel = SignInViewModel();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 40), // 전체적인 좌우 패딩 추가
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              SizedBox(height: 40),
+              CustomTextFormField(
+                controller: viewModel.emailController,
+                hintText: '아이디를 입력해주세요',
+              ),
+              SizedBox(height: 20),
+              CustomTextFormField(
+                controller: viewModel.passwordController,
+                hintText: '비밀번호를 입력해주세요',
+                obscureText: true, // 비밀번호 입력 필드는 obscureText를 true로 설정
+              ),
+              SizedBox(height: 20),
+              CustomTextFormField(
+                controller: viewModel.nameController,
+                hintText: '이름를 입력해주세요',
+              ),
+              SizedBox(height: 20),
+              CustomTextFormField(
+                controller: viewModel.phoneController,
+                hintText: '전화번호를 입력해주세요',
+              ),
+              SizedBox(height: 30),
+
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  // 반려인 버튼
+                  ElevatedButton(
+                    onPressed: () => viewModel.membertypeController.text = 'B',
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Colors.black, backgroundColor: Color(0xFFA273FF),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                    ),
+                    child: Text('반려인'),
+                  ),
+                  SizedBox(width: 20),
+                  // 보호소 버튼
+                  ElevatedButton(
+                    onPressed: () => viewModel.membertypeController.text = 'S',
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Colors.black, backgroundColor: Color(0xFFA273FF),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                    ),
+                    child: Text('보호소'),
+                  ),
+                ],
+              ),
+              SizedBox(height: 20),
+
+              ElevatedButton(
+                onPressed: () => viewModel.printAllControllerValues(),
+                style: ElevatedButton.styleFrom(
+                  foregroundColor: Colors.black, backgroundColor: Color(0xFFA273FF),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                ),
+                child: Text('출력값 확인'),
+              ),
+
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Color(0xFFA273FF),
+                  minimumSize: Size(double.infinity, 50),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                onPressed: () async {
+                  bool isSuccess = await viewModel.attemptSignIn();
+                  if (isSuccess) {
+                    Get.to(LoginScreen());
+                  } else {
+                    print("Sign in failed");
+                  }
+                },
+                child: Text(
+                  '회원가입',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 24,
+                    fontFamily: 'Pretendard',
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              SizedBox(height: 10),
+              Spacer(flex: 3), // 하단 공간
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class CustomTextFormField extends StatelessWidget {
+  final TextEditingController controller;
+  final String hintText;
+  final bool obscureText;
+
+  const CustomTextFormField({
+    Key? key,
+    required this.controller,
+    required this.hintText,
+    this.obscureText = false, // 기본값은 false입니다.
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      obscureText: obscureText, // 비밀번호 필드인 경우 true로 설정합니다.
+      decoration: InputDecoration(
+        hintText: hintText,
+        fillColor: Color(0xFFF7F4FF),
+        filled: true,
+        hintStyle: TextStyle(
+          color: Colors.grey[500],
+          fontFamily: 'Pretendard',
+          fontWeight: FontWeight.w500,
+          fontSize: 16,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(10),
+          borderSide: BorderSide.none,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/login/signin_screen.dart
+++ b/lib/views/login/signin_screen.dart
@@ -3,77 +3,101 @@ import 'package:bommeong/views/login/login_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:get/get_core/src/get_main.dart';
+import '../../utilities/font_system.dart';
 
 class SignInScreen extends StatelessWidget {
   final viewModel = SignInViewModel();
+  final String membertype;
+
+  SignInScreen({Key? key, required this.membertype}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    viewModel.membertypeController.text = membertype;
+
     return Scaffold(
+      appBar: AppBar(
+        title: Text('회원가입', style: FontSystem.KR20B.copyWith(color: Colors.black),),
+      ),
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 40), // 전체적인 좌우 패딩 추가
+          padding: const EdgeInsets.all(30), // 전체적인 좌우 패딩 추가
           child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              SizedBox(height: 40),
-              CustomTextFormField(
-                controller: viewModel.emailController,
-                hintText: '아이디를 입력해주세요',
+              Text(' 아이디', style: FontSystem.KR17SB.copyWith(color: Color(0xFF848484)),),
+              SizedBox(height: 12),
+              Row(
+                children: [
+                  CustomTextFormField(
+                    controller: viewModel.emailController,
+                    hintText: '아이디를 입력해주세요',
+                    width: (Get.width - 60 - (Get.width * 0.03)) * 0.65, // 수정: 나머지 공간의 대부분을 사용
+                  ),
+                  SizedBox(width: Get.width * 0.03), // 필드와 버튼 사이의 간격
+                  Container(
+                    width: (Get.width - 60 - (Get.width * 0.03)) * 0.35, // 버튼의 너비를 조정
+                    child: ElevatedButton(
+                      onPressed: () {
+                        print("중복 확인 버튼 클릭됨");
+                      },
+                      style: ElevatedButton.styleFrom(
+                        primary: Color(0xFFA273FF), // 버튼 배경색
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10), // 버튼 모서리 둥글게
+                        ),
+                      ),
+                      child: Text(
+                        '중복 확인',
+                        style: FontSystem.KR15SB.copyWith(color: Colors.white),
+                      ),
+                    ),
+                  ),
+                ],
               ),
-              SizedBox(height: 20),
+
+              SizedBox(height: 40),
+              Text(' 비밀번호', style: FontSystem.KR17SB.copyWith(color: Color(0xFF848484)),),
+              SizedBox(height: 12),
               CustomTextFormField(
                 controller: viewModel.passwordController,
                 hintText: '비밀번호를 입력해주세요',
                 obscureText: true, // 비밀번호 입력 필드는 obscureText를 true로 설정
               ),
-              SizedBox(height: 20),
+              SizedBox(height: 13),
+              CustomTextFormField(
+                controller: viewModel.confirmPasswordController, // 수정된 부분
+                hintText: '비밀번호를 다시 입력해주세요',
+                obscureText: true,
+              ),
+              SizedBox(height: 40),
+              Text(' 이름', style: FontSystem.KR17SB.copyWith(color: Color(0xFF848484)),),
+              SizedBox(height: 12),
               CustomTextFormField(
                 controller: viewModel.nameController,
-                hintText: '이름를 입력해주세요',
+                hintText: '이름을 입력해주세요',
               ),
-              SizedBox(height: 20),
+
+
+              SizedBox(height: 40),
+              Text(' 휴대폰 번호', style: FontSystem.KR17SB.copyWith(color: Color(0xFF848484)),),
+              SizedBox(height: 12),
               CustomTextFormField(
                 controller: viewModel.phoneController,
                 hintText: '전화번호를 입력해주세요',
               ),
               SizedBox(height: 30),
 
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  // 반려인 버튼
-                  ElevatedButton(
-                    onPressed: () => viewModel.membertypeController.text = 'B',
-                    style: ElevatedButton.styleFrom(
-                      foregroundColor: Colors.black, backgroundColor: Color(0xFFA273FF),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-                    ),
-                    child: Text('반려인'),
-                  ),
-                  SizedBox(width: 20),
-                  // 보호소 버튼
-                  ElevatedButton(
-                    onPressed: () => viewModel.membertypeController.text = 'S',
-                    style: ElevatedButton.styleFrom(
-                      foregroundColor: Colors.black, backgroundColor: Color(0xFFA273FF),
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-                    ),
-                    child: Text('보호소'),
-                  ),
-                ],
-              ),
-              SizedBox(height: 20),
+              // ElevatedButton(
+              //   onPressed: () => viewModel.printAllControllerValues(),
+              //   style: ElevatedButton.styleFrom(
+              //     foregroundColor: Colors.black, backgroundColor: Color(0xFFA273FF),
+              //     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+              //   ),
+              //   child: Text('출력값 확인'),
+              // ),
 
-              ElevatedButton(
-                onPressed: () => viewModel.printAllControllerValues(),
-                style: ElevatedButton.styleFrom(
-                  foregroundColor: Colors.black, backgroundColor: Color(0xFFA273FF),
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-                ),
-                child: Text('출력값 확인'),
-              ),
-
+              Spacer(flex: 3,),
               ElevatedButton(
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Color(0xFFA273FF),
@@ -83,15 +107,20 @@ class SignInScreen extends StatelessWidget {
                   ),
                 ),
                 onPressed: () async {
-                  bool isSuccess = await viewModel.attemptSignIn();
-                  if (isSuccess) {
-                    Get.to(LoginScreen());
+                  if (viewModel.passwordController.text == viewModel.confirmPasswordController.text) {
+                    // 비밀번호가 일치하면 로그인 시도
+                    bool isSuccess = await viewModel.attemptSignIn();
+                    if (isSuccess) {
+                      Get.to(LoginScreen());
+                    } else {
+                      print("Sign in failed");
+                    }
                   } else {
-                    print("Sign in failed");
+                    print("비밀번호를 알맞게 입력해주세요!");
                   }
                 },
                 child: Text(
-                  '회원가입',
+                  '가입 완료',
                   style: TextStyle(
                     color: Colors.white,
                     fontSize: 24,
@@ -100,8 +129,6 @@ class SignInScreen extends StatelessWidget {
                   ),
                 ),
               ),
-              SizedBox(height: 10),
-              Spacer(flex: 3), // 하단 공간
             ],
           ),
         ),
@@ -114,32 +141,48 @@ class CustomTextFormField extends StatelessWidget {
   final TextEditingController controller;
   final String hintText;
   final bool obscureText;
+  final double? width; // 가로 길이를 설정하기 위한 선택적 파라미터
 
   const CustomTextFormField({
     Key? key,
     required this.controller,
     required this.hintText,
     this.obscureText = false, // 기본값은 false입니다.
+    this.width,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return TextFormField(
-      controller: controller,
-      obscureText: obscureText, // 비밀번호 필드인 경우 true로 설정합니다.
-      decoration: InputDecoration(
-        hintText: hintText,
-        fillColor: Color(0xFFF7F4FF),
-        filled: true,
-        hintStyle: TextStyle(
-          color: Colors.grey[500],
-          fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w500,
-          fontSize: 16,
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(10),
-          borderSide: BorderSide.none,
+    return Container(
+      width: width, // Container의 가로 길이 설정
+      height: 45, // Container의 높이를 45로 고정
+      child: TextFormField(
+        controller: controller,
+        obscureText: obscureText, // 비밀번호 필드인 경우 true로 설정
+        decoration: InputDecoration(
+          hintText: hintText,
+          fillColor: Color(0xFFF7F4FF),
+          filled: true,
+          contentPadding: EdgeInsets.fromLTRB(10, 0, 0, 0), // 왼쪽에서 패딩 10만 줌
+          hintStyle: TextStyle(
+            color: Colors.grey[500],
+            fontFamily: 'Pretendard',
+            fontWeight: FontWeight.w500,
+            fontSize: 15,
+          ),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+            borderSide: BorderSide.none,
+          ),
+          // 높이 조정을 위해 inputBorder의 높이 조정을 제거
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+            borderSide: BorderSide.none,
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(10),
+            borderSide: BorderSide.none,
+          ),
         ),
       ),
     );

--- a/lib/views/widget/adoption/Question.dart
+++ b/lib/views/widget/adoption/Question.dart
@@ -3,7 +3,6 @@ import 'package:bommeong/viewModels/root/root_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controller/responses_controller.dart';
-import '../privacy/privacy_consent_screen.dart';
 
 // 상태 관리를 위한 ResponsesController 인스턴스 생성
 final ResponsesController responsesController = Get.put(ResponsesController());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -509,30 +509,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   linkify:
     dependency: transitive
     description:
@@ -553,26 +529,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -593,10 +569,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   path_parsing:
     dependency: transitive
     description:
@@ -970,14 +946,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0+2"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.0"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
## 🔥 Related Issues

-   close #27 

## ⛅️ 작업 내용

- [x] 입양자, 공고자 구분하기 스크린 구현 
- [x] 회원가입(아이디, 패스워드, 이메일, 전화번호 입력) 구현 
- [x] 로그인 api 연동
- [x] 회원가입 api 연동

## 👀 스크린샷 / GIF / 링크

https://github.com/goormthon-Univ/2024_BEOTKKOTTHON_TEAM_9_FE/assets/59414536/e5f9dd05-880c-4cc1-9b1d-ea9c758cd3e9

